### PR TITLE
Allow stdlib 9.x and letsencrypt 13.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     },
     {
       "name": "puppet-letsencrypt",
-      "version_requirement": ">= 9.0.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 14.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I'm using this module successfully with puppetlabs-stdlib 9.7.0 and puppet-letsencrypt 13.1.0.