### PR TITLE
`init.pp`: use `fullchain.pem` instead of `cert.pem`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -117,7 +117,7 @@ class pe_console_letsencrypt (
     group     => $group,
     links     => 'follow',
     mode      => $mode,
-    source    => "${letsencrypt_conf_dir}/live/${facts['puppet_server']}/cert.pem",
+    source    => "${letsencrypt_conf_dir}/live/${facts['puppet_server']}/fullchain.pem",
     backup    => '.puppet_bak',
     notify    => Service['pe-nginx'],
     require   => Exec['restart_nginx'],


### PR DESCRIPTION
Per https://eff-certbot.readthedocs.io/en/latest/using.html#where-are-my-certificates and `/etc/letsencrypt/live/README`, `fullchain.pem` is the correct certificate file to use.